### PR TITLE
Choose image name and support to download image from a uInt8List

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -129,7 +129,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -190,7 +197,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -218,7 +225,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/web_image_downloader.dart
+++ b/lib/src/web_image_downloader.dart
@@ -9,6 +9,7 @@ class WebImageDownloader {
     String url, {
     Map<String, String>? headers,
     double imageQuality = 0.95,
+    String? name,
   }) async {
     final http.Response res = await http.get(
       Uri.parse(url),
@@ -16,18 +17,20 @@ class WebImageDownloader {
     );
 
     if (res.statusCode == 200) {
-      await _downloadImageFromUInt8List(
+      await downloadImageFromUInt8List(
         uInt8List: res.bodyBytes,
         imageQuality: imageQuality,
+        name: name,
       );
     } else {
       throw Exception(res.statusCode);
     }
   }
 
-  Future<void> _downloadImageFromUInt8List({
+  Future<void> downloadImageFromUInt8List({
     required Uint8List uInt8List,
     required double imageQuality,
+    String? name,
   }) async {
     final image = await decodeImageFromList(uInt8List);
 
@@ -59,7 +62,7 @@ class WebImageDownloader {
       final dataUrl = canvas.toDataUrl("image/jpeg", imageQuality);
       final html.AnchorElement anchorElement =
           html.AnchorElement(href: dataUrl);
-      anchorElement.download = dataUrl;
+      anchorElement.download = name ?? dataUrl;
       anchorElement.click();
     });
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -115,7 +115,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -176,7 +183,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -204,7 +211,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
Hello there,

**Choose image name**
The images are downloaded with the name: "data_image_jpeg;*.jpeg". It should be a good idea to let the user/programmer decide what the name should be.

**Support to download image from a uInt8List**
It may be a good idea to support downloading images from their uInt8List data directly. I came across a use-case this morning where I needed to create an image from a widget, which I did by doing something similar to [this](https://mukhtharcm.com/create-image-from-widget-flutter/) and got a uInt8List, so I needed to download it.
So it may be a good idea to let the ```downloadImageFromUInt8List``` method be public.

Love to hear your thoughts.