### PR TITLE
feat: add file extension jpg on ImageType

### DIFF
--- a/lib/src/image_type.dart
+++ b/lib/src/image_type.dart
@@ -12,7 +12,7 @@ enum ImageType {
   jpeg('image/jpeg'),
   
   /// Joint Photographic Expert Group image (JPEG)
-  jpeg('image/jpg'),
+  jpg('image/jpg'),
 
   /// Portable Network Graphics (PNG)
   png('image/png'),

--- a/lib/src/image_type.dart
+++ b/lib/src/image_type.dart
@@ -10,6 +10,9 @@ enum ImageType {
 
   /// Joint Photographic Expert Group image (JPEG)
   jpeg('image/jpeg'),
+  
+  /// Joint Photographic Expert Group image (JPEG)
+  jpeg('image/jpg'),
 
   /// Portable Network Graphics (PNG)
   png('image/png'),

--- a/lib/src/web_image_downloader.dart
+++ b/lib/src/web_image_downloader.dart
@@ -24,6 +24,7 @@ class WebImageDownloader {
         uInt8List: res.bodyBytes,
         imageQuality: imageQuality,
         name: name,
+        imageType: imageType,
       );
     } else {
       throw Exception(res.statusCode);


### PR DESCRIPTION
Adding a `jpg` extension file, and fix a bug when call `downloadImageFromWeb`. The argument `imageType` was not pass to the method `downloadImageFromUInt8List`.